### PR TITLE
add automatic rebundling via watchify, run migrations on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ venv/
 socodri.egg-info/
 db.sqlite3
 local_config.py
-bundle.js
 node_modules/
+static/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,12 @@ RUN npm install
 # set up django app
 ADD requirements.txt /usr/src/app
 RUN pip install -r requirements.txt
+
+# copy local files
 ADD . .
+
+# bundle the js
+RUN npm run bundle
+
+# run our migrations
+RUN python manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ scarab:
 django:
   build: .
   env_file: .env
-  command: python manage.py runserver 0.0.0.0:8000
+  command: npm start
   ports:
     - "8000:8000"
   volumes:

--- a/package.json
+++ b/package.json
@@ -1,18 +1,23 @@
 {
-    "dependencies": {
-        "scarab-django": "jesseditson/scarab-django",
-        "scarab": "jesseditson/scarab"
-    },
-    "scarab": {
-        "parent": "jesseditson/scarab-django"
-    },
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "name": "socodri",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "author": "",
-    "license": "ISC"
+  "dependencies": {
+    "scarab": "jesseditson/scarab",
+    "scarab-django": "jesseditson/scarab-django",
+    "superagent": "^1.6.1"
+  },
+  "scarab": {
+    "parent": "jesseditson/scarab-django"
+  },
+  "scripts": {
+    "start": "npm run watch & python manage.py runserver 0.0.0.0:8000",
+    "watch": "watchify --poll -v -t hbsify -t babelify static/js/main.js -o static/dist/js/bundle.js",
+    "bundle": "browserify -t hbsify -t babelify static/js/main.js -o static/dist/js/bundle.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "install": "mkdir -p static/dist"
+  },
+  "name": "socodri",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC"
 }

--- a/socodri/templates/app.html
+++ b/socodri/templates/app.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="{% static 'css/irishcream.css' %}">
     <link rel="stylesheet" href="{% static 'css/app.css' %}">
     <link rel="icon" type="img/ico" href="{% static 'media/favicon.png' %}">
-    <script src="{% static 'bundle.js' %}"></script>
+    <script src="{% static 'dist/js/bundle.js' %}"></script>
     <title>Socialcode DR Insights</title>
   </head>
   <body>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,11 @@
+var request = require('superagent')
+
+request
+  .get('/ping')
+  .end(function(err, response) {
+    if (err) {
+      console.error(`error contacting server: ${err.message}`)
+    } else {
+      console.log(`pinged server, response: ${response.text}`)
+    }
+  })


### PR DESCRIPTION
- migrations now automatically run when running `scarab build`
- added `static/js/main.js` file, which is the js entry point that will be compiled by browserify/watchify
- added automatic js bundling when running `scarab build`
- added watchify so js will recompile every time it is changed
- added example of calling the server from js

Notes:
- your local env will need to re-run `npm install` to pick up the new dependencies
- after running `npm install`, run `scarab build`, then restart the scarab container by running `scarab stop` then `scarab start`
- if you see any errors, remember to tail the logs with `scarab logs` to see what's going on.
